### PR TITLE
악보 채점 방식 수정 및 api에 설명 추가

### DIFF
--- a/backend/audio-service/src/main/java/com/capstone/service/AudioMessageConsumer.java
+++ b/backend/audio-service/src/main/java/com/capstone/service/AudioMessageConsumer.java
@@ -70,7 +70,7 @@ public class AudioMessageConsumer {
         MeasureInfo measureInfo = onsetMeasureData.getMeasureInfo();
         List<Boolean> beatScoringResults = practiceResultResolver.calculateBeatMatchingResult(onsetMatchResult);
         List<Boolean> finalScoringResults = practiceResultResolver.calculateFinalMatchingResult(onsetMatchResult, predictList, measureInfo);
-        double score = practiceResultResolver.calculateScore(finalScoringResults);
+        double score = practiceResultResolver.calculateScore(beatScoringResults, finalScoringResults);
         return FinalMeasureResult.builder()
                 .measureNumber(measureNumber)
                 .beatScoringResults(beatScoringResults)

--- a/backend/audio-service/src/main/java/com/capstone/service/PracticeResultResolver.java
+++ b/backend/audio-service/src/main/java/com/capstone/service/PracticeResultResolver.java
@@ -16,6 +16,8 @@ import java.util.List;
 @Component
 public class PracticeResultResolver {
 
+    public static final Double errorThreshold = 0.2;
+
     public OnsetMatchResult matchOnset(ModelDto.OnsetResponseDto onsetResponse, MeasureInfo measureInfo){
         List<Double> userOnset = onsetResponse
                 .getOnsets()
@@ -23,7 +25,6 @@ public class PracticeResultResolver {
                 .map(Double::parseDouble)
                 .toList();
         List<Double> answerOnset = new ArrayList<>();
-        double errorThreshold = 0.05;
         List<NoteInfo> noteInfoList = measureInfo.getNoteList();
         for(NoteInfo noteInfo : noteInfoList){
             answerOnset.add(noteInfo.getStartOnset());
@@ -31,14 +32,19 @@ public class PracticeResultResolver {
         return DTWMatcher.match(userOnset, answerOnset, errorThreshold);
     }
 
-    public double calculateScore(List<Boolean> finalMatchingResult){
-        int successCount = 0;
-        for(Boolean result : finalMatchingResult){
-            if(result){
-                successCount++;
-            }
+    public double calculateScore(
+            List<Boolean> beatMatchingResult,
+            List<Boolean> finalMatchingResult){
+        int size = beatMatchingResult.size();
+        double score = 0;
+        double unitScore = (double) 100 / size;
+        for(int i=0; i<size; i++){
+            if(beatMatchingResult.get(i))
+                score += (unitScore*0.7);
+            if(finalMatchingResult.get(i))
+                score += (unitScore*0.3);
         }
-        return ((double) successCount / finalMatchingResult.size()) * 100;
+        return Math.ceil(score);
     }
 
     public List<Boolean> calculateBeatMatchingResult(OnsetMatchResult onsetMatchResult){

--- a/backend/audio-service/src/test/java/com/capstone/service/PracticeResultResolverTest.java
+++ b/backend/audio-service/src/test/java/com/capstone/service/PracticeResultResolverTest.java
@@ -76,13 +76,15 @@ class PracticeResultResolverTest {
         List<Boolean> mustBe50 = List.of(true, true, true, false, false, false);
         List<Boolean> mustBe0 = List.of(false, false, false, false, false, false);
         // when
-        double scoreMust0 = resultResolver.calculateScore(mustBe0);
-        double scoreMust50 = resultResolver.calculateScore(mustBe50);
-        double scoreMust100 = resultResolver.calculateScore(mustBe100);
+        double scoreMust70 = resultResolver.calculateScore(mustBe100, mustBe0);
+        double scoreMust85 = resultResolver.calculateScore(mustBe100, mustBe50);
+        double scoreMust100 = resultResolver.calculateScore(mustBe100, mustBe100);
+        double scoreMust0 = resultResolver.calculateScore(mustBe0, mustBe0);
         // then
         assertEquals(100.0, scoreMust100);
-        assertEquals(50.0, scoreMust50);
-        assertEquals(0.0, scoreMust0);
+        assertEquals(85.0, scoreMust85);
+        assertEquals(70.0, scoreMust70);
+        assertEquals(0, scoreMust0);
     }
 
     @Test

--- a/backend/gateway-service/src/main/java/com/capstone/security/SecurityConfig.java
+++ b/backend/gateway-service/src/main/java/com/capstone/security/SecurityConfig.java
@@ -50,6 +50,10 @@ public class SecurityConfig {
             // audio service
             "/audio/practice/**",
     };
+    private final String[] WHITE_LIST_PUT = {
+            // user service
+            "/users/password",
+    };
     private JwtAuthFilter jwtAuthFilter;
     public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
         this.jwtAuthFilter = jwtAuthFilter;
@@ -65,6 +69,7 @@ public class SecurityConfig {
                     exchange.pathMatchers(WHITE_LIST).permitAll();
                     exchange.pathMatchers(HttpMethod.GET ,WHITE_LIST_GET).permitAll();
                     exchange.pathMatchers(HttpMethod.POST, WHITE_LIST_POST).permitAll();
+                    exchange.pathMatchers(HttpMethod.PUT, WHITE_LIST_PUT).permitAll();
                     exchange.anyExchange().authenticated();
                 });
         return http.build();

--- a/backend/music-service/src/main/java/com/capstone/config/FakeDataGenerator.java
+++ b/backend/music-service/src/main/java/com/capstone/config/FakeDataGenerator.java
@@ -1,5 +1,7 @@
 package com.capstone.config;
 
+import com.capstone.dto.musicXml.MeasureInfo;
+import com.capstone.dto.musicXml.NoteInfo;
 import com.capstone.dto.musicXml.PartInfo;
 import com.capstone.dto.score.FinalMeasureResult;
 import com.capstone.practice.entity.SheetPractice;
@@ -21,10 +23,7 @@ import org.springframework.stereotype.Component;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
+import java.util.*;
 
 @Component
 @Profile("dev")
@@ -48,11 +47,13 @@ public class FakeDataGenerator {
                 .getInputStream()) {
             sheetXml = inputStream.readAllBytes();
         }
-        String sheetJson = objectMapper.writeValueAsString(sheetXmlInfoParser.parseXmlInfo(sheetXml));
+        List<PartInfo> sheetPureJson = sheetXmlInfoParser.parseXmlInfo(sheetXml);
+        String practiceJson = getPracticeInfo(sheetPureJson);
+        String sheetJson = objectMapper.writeValueAsString(sheetPureJson);
         String testUser = "test@test.com";
         List<Sheet> sheets = generateSheets(faker, sheetXml, sheetJson, 10);
         List<UserSheet> userSheets = generateUserSheets(faker, sheets, testUser);
-        generateSheetPractices(faker, userSheets, 10, testUser);
+        generateSheetPractices(faker, userSheets, practiceJson,10, testUser);
     }
     /**
      * generate fake data for sheets
@@ -94,30 +95,61 @@ public class FakeDataGenerator {
     /**
     * generate fake sheet practices
     * */
-    public void generateSheetPractices(Faker faker, List<UserSheet> userSheets, int countPerSheet, String testUser) throws Exception{
-        FinalMeasureResult finalMeasureResult = FinalMeasureResult.builder()
-                .score((double) faker.number().numberBetween(1, 100))
-                .beatScoringResults(List.of(true, true, true, true, true))
-                .finalScoringResults(List.of(true, true, true, true, true)).build();
+    public void generateSheetPractices(
+            Faker faker,
+            List<UserSheet> userSheets,
+            String practiceJson,
+            int countPerSheet,
+            String testUser) throws Exception{
         for(UserSheet userSheet: userSheets){
             for(int i=0; i<countPerSheet; i++){
-                int measureNumber = 1;
-                List<FinalMeasureResult> finalMeasureResults = new ArrayList<>();
-                for(int j=0; j<10; j++){
-                    finalMeasureResult.setMeasureNumber(Integer.toString(measureNumber++));
-                    finalMeasureResults.add(finalMeasureResult);
-                }
-                String practiceInfo = new ObjectMapper().writeValueAsString(finalMeasureResults);
                 sheetPracticeRepository.save(
                         SheetPractice.builder()
                                 .userSheet(userSheet)
                                 .score(faker.number().numberBetween(1, 100))
-                                .practiceInfo(practiceInfo)
+                                .practiceInfo(practiceJson)
                                 .userEmail(testUser)
                                 .createdDate(LocalDateTime.now())
                                 .build()
                 );
             }
         }
+    }
+
+    public List<Boolean> getRandomBooleans(int count){
+        Random random = new Random();
+        List<Boolean> booleans = new ArrayList<>();
+        for(int i=0; i<count; i++){
+            booleans.add(random.nextBoolean());
+        }
+        return booleans;
+    }
+
+    public String getPracticeInfo(List<PartInfo> sheetPureJson) throws Exception {
+        List<FinalMeasureResult> finalMeasureResults = new ArrayList<>();
+        for(PartInfo partInfo: sheetPureJson){
+            for(MeasureInfo measureInfo : partInfo.getMeasureList()){
+                String measureNumber = measureInfo.getMeasureNumber();
+                int noteCount = measureInfo.getNoteList().size();
+                int score = 0;
+                List<Boolean> beatScoringResults = getRandomBooleans(noteCount);
+                List<Boolean> finalScoringResults = getRandomBooleans(noteCount);
+                for(int i=0; i<noteCount; i++){
+                    double resScore = 0;
+                    double unitScore = (double) 100 / noteCount;
+                    if(beatScoringResults.get(i)) resScore += (unitScore * 0.7);
+                    if(finalScoringResults.get(i)) resScore += (unitScore * 0.3);
+                    score += (int) resScore;
+                }
+                FinalMeasureResult finalMeasureResult = FinalMeasureResult.builder()
+                        .beatScoringResults(beatScoringResults)
+                        .finalScoringResults(finalScoringResults)
+                        .score((double) score)
+                        .measureNumber(measureNumber)
+                        .build();
+                finalMeasureResults.add(finalMeasureResult);
+            }
+        }
+        return objectMapper.writeValueAsString(finalMeasureResults);
     }
 }

--- a/backend/music-service/src/main/java/com/capstone/practice/controller/SheetPracticeManageController.java
+++ b/backend/music-service/src/main/java/com/capstone/practice/controller/SheetPracticeManageController.java
@@ -5,6 +5,7 @@ import com.capstone.enums.SuccessFlag;
 import com.capstone.practice.service.SheetPracticeManageService;
 import com.capstone.response.ApiResponse;
 import com.capstone.response.CustomResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,12 +18,14 @@ public class SheetPracticeManageController {
     private final SheetPracticeManageService sheetPracticeManageService;
 
     @PostMapping("/{userSheetId}/practices")
+    @Operation(summary = "create sheet practice record")
     public ResponseEntity<CustomResponseDto<String>> createPractice(@PathVariable("userSheetId") int userSheetId, @RequestBody MusicServiceClientDto.SheetPracticeCreateRequest sheetPracticeCreateRequest) {
         sheetPracticeManageService.saveSheetPractice(sheetPracticeCreateRequest);
         return ApiResponse.success(SuccessFlag.SUCCESS.getLabel());
     }
 
     @DeleteMapping("/practices/{sheetPracticeId}")
+    @Operation(summary = "delete practice record by id")
     public ResponseEntity<CustomResponseDto<String>> deletePractice(@PathVariable("sheetPracticeId") int sheetPracticeId) {
         sheetPracticeManageService.deleteSheetPractice(sheetPracticeId);
         return ApiResponse.success(SuccessFlag.SUCCESS.getLabel());

--- a/backend/music-service/src/main/java/com/capstone/practice/controller/SheetPracticeRetrieveController.java
+++ b/backend/music-service/src/main/java/com/capstone/practice/controller/SheetPracticeRetrieveController.java
@@ -6,6 +6,7 @@ import com.capstone.practice.dto.SheetPracticeResponseDto;
 import com.capstone.practice.service.SheetPracticeRetrieveService;
 import com.capstone.response.ApiResponse;
 import com.capstone.response.CustomResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +28,7 @@ public class SheetPracticeRetrieveController {
      * @return 악보 연습 목록 반환
     * */
     @GetMapping("/{userSheetId}/practices")
+    @Operation(summary = "get practice by user's sheet id")
     private ResponseEntity<CustomResponseDto<List<SheetPracticeResponseDto>>> getPractices(
             @PathVariable("userSheetId") int userSheetId,
             @RequestParam("pageSize") int pageSize,
@@ -41,6 +43,7 @@ public class SheetPracticeRetrieveController {
      * @return 악보 연습 상세 정보 반환
     * */
     @GetMapping("/practices/{practiceId}")
+    @Operation(summary = "get practice by sheet practice id")
     private ResponseEntity<CustomResponseDto<SheetPracticeDetailResponseDto>> getDetailPractice(@PathVariable("practiceId") int practiceId) {
         SheetPracticeDetailResponseDto res = sheetPracticeRetrieveService.getDetailSheetPracticeRecord(practiceId);
         return ApiResponse.success(res);
@@ -52,6 +55,7 @@ public class SheetPracticeRetrieveController {
      * @return 악보 대표 연습 정보 반환
     * */
     @GetMapping("/{userSheetId}/practices/representative")
+    @Operation(summary = "get representative practice record of specific sheet")
     private ResponseEntity<CustomResponseDto<SheetPracticeRepresentResponse>> getRepresentativePractice(
             @PathVariable("userSheetId") int userSheetId,
             @RequestParam("email") String email) {
@@ -64,6 +68,7 @@ public class SheetPracticeRetrieveController {
      * @return 악보 대표 연습 정보 목록
     * */
     @GetMapping("/practices/representative")
+    @Operation(summary = "get all user's sheet representative practice record by email")
     public ResponseEntity<CustomResponseDto<List<SheetPracticeRepresentResponse>>> getRepresentativePractices(@RequestParam("email") String email){
         List<SheetPracticeRepresentResponse> res = sheetPracticeRetrieveService.getRepresentSheetPractices(email);
         return ApiResponse.success(res);

--- a/backend/music-service/src/main/java/com/capstone/sheet/controller/PatternManageController.java
+++ b/backend/music-service/src/main/java/com/capstone/sheet/controller/PatternManageController.java
@@ -7,6 +7,7 @@ import com.capstone.sheet.dto.PatternCreateDto;
 import com.capstone.sheet.dto.PatternResponseDto;
 import com.capstone.sheet.event.PatternCreateEvent;
 import com.capstone.sheet.service.PatternManageService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
@@ -24,6 +25,7 @@ public class PatternManageController {
     private final ApplicationEventPublisher eventPublisher;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "create pattern data")
     public ResponseEntity<CustomResponseDto<String>> createPattern(
             @RequestPart PatternCreateDto patternCreateDto,
             @RequestPart MultipartFile sheetFile) throws Exception{
@@ -32,11 +34,13 @@ public class PatternManageController {
     }
 
     @PutMapping("/{patternId}")
+    @Operation(summary = "update pattern info by id")
     public ResponseEntity<CustomResponseDto<PatternResponseDto>> updatePattern(@PathVariable("patternId") Long patternId, @RequestBody PatternCreateDto patternCreateDto){
         return ApiResponse.success(patternManageService.updatePattern(patternId, patternCreateDto));
     }
 
     @DeleteMapping("/{patternId}")
+    @Operation(summary = "delete pattern by pattern id")
     public ResponseEntity<CustomResponseDto<String>> deletePattern(@PathVariable("patternId") Long patternId){
         patternManageService.deletePattern(patternId);
         return ApiResponse.success(SuccessFlag.SUCCESS.getLabel());

--- a/backend/music-service/src/main/java/com/capstone/sheet/controller/SheetManageController.java
+++ b/backend/music-service/src/main/java/com/capstone/sheet/controller/SheetManageController.java
@@ -10,6 +10,7 @@ import com.capstone.sheet.dto.SheetResponseDto;
 import com.capstone.sheet.dto.SheetUpdateRequestDto;
 import com.capstone.sheet.service.SheetManageService;
 import com.capstone.sheet.service.SheetUpdateService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import org.springframework.http.MediaType;
@@ -32,6 +33,7 @@ public class SheetManageController {
      * @param sheetFile 악보 파일 (pdf 혹은 이미지)
     * */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "create user's sheet")
     public ResponseEntity<CustomResponseDto<SheetResponseDto>> createSheet(
             @RequestPart("sheetCreateMeta") SheetCreateMeta sheetCreateMeta,
             @RequestPart("sheetFile") MultipartFile sheetFile){
@@ -44,6 +46,7 @@ public class SheetManageController {
      * @return SheetResponseDto
     * */
     @PutMapping("/{userSheetId}/name")
+    @Operation(summary = "update user's sheet name")
     public ResponseEntity<CustomResponseDto<SheetResponseDto>> updateSheetName(
             @PathVariable("userSheetId") int userSheetId,
             @RequestBody SheetUpdateRequestDto requestDto) {
@@ -63,6 +66,7 @@ public class SheetManageController {
      * @return SheetResponseDto
      * */
     @PutMapping("/{userSheetId}/color")
+    @Operation(summary = "update user's sheet color")
     public ResponseEntity<CustomResponseDto<SheetResponseDto>> updateSheetColor(
     @PathVariable("userSheetId") int userSheetId,
     @RequestBody SheetUpdateRequestDto requestDto) {
@@ -82,6 +86,7 @@ public class SheetManageController {
      * @return valid | invalid
      * */
     @DeleteMapping("")
+    @Operation(summary = "delete user's sheet by id list")
     public ResponseEntity<CustomResponseDto<String>> deleteSheet(
             @RequestParam("email") String email,
             @RequestBody SheetListRequestDto requestDto) {

--- a/backend/music-service/src/main/java/com/capstone/sheet/controller/SheetRetrieveController.java
+++ b/backend/music-service/src/main/java/com/capstone/sheet/controller/SheetRetrieveController.java
@@ -6,6 +6,7 @@ import com.capstone.sheet.dto.SheetDetailResponseDto;
 import com.capstone.sheet.dto.SheetListResponseDto;
 import com.capstone.dto.musicXml.MeasureInfo;
 import com.capstone.sheet.service.SheetRetrieveService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,7 @@ public class SheetRetrieveController {
      * @return SheetResponseDto
     * */
     @GetMapping("")
+    @Operation(summary = "retrieve all user sheets by email")
     public ResponseEntity<CustomResponseDto<SheetListResponseDto>> retrieveSheets(@RequestParam("email") String email) {
         return ApiResponse.success(new SheetListResponseDto(sheetRetrieveService.getSheetsByEmail(email)));
     }
@@ -31,6 +33,7 @@ public class SheetRetrieveController {
      * @return CustomResponseDto<SheetDetailResponseDto>
     * */
     @GetMapping("/{userSheetId}")
+    @Operation(summary = "retrieve user sheet's detail info by id")
     public ResponseEntity<CustomResponseDto<SheetDetailResponseDto>> retrieveSheetDetails(@PathVariable("userSheetId") int userSheetId) {
         return ApiResponse.success(sheetRetrieveService.getSheetById(userSheetId));
     }
@@ -41,6 +44,7 @@ public class SheetRetrieveController {
      * @return CustomResponseDto<MeasureInfo>
     * */
     @GetMapping("/{userSheetId}/measures")
+    @Operation(summary = "get sheet's measure info by user sheet and measure number")
     public ResponseEntity<CustomResponseDto<MeasureInfo>> retrieveSheetMeasure(
             @PathVariable("userSheetId") int userSheetId,
             @RequestParam("measureNumber") String measureNumber) {

--- a/backend/user-service/src/main/java/com/capstone/controller/UserManagementController.java
+++ b/backend/user-service/src/main/java/com/capstone/controller/UserManagementController.java
@@ -11,6 +11,7 @@ import com.capstone.response.ApiResponse;
 import com.capstone.response.CustomResponseDto;
 import com.capstone.service.UserRetrieveService;
 import com.capstone.service.UserUpdateService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,25 +31,34 @@ public class UserManagementController {
         this.userRetrieveService = userRetrieveService;
     }
     @GetMapping("/email")
+    @Operation(summary = "find user by email")
     public ResponseEntity<CustomResponseDto<UserResponseDto>> findUserByEmail(@RequestParam("email") String email) {
         User user = userRetrieveService.getUserOrExceptionByEmail(email);
         return ApiResponse.success(user.toResponseDto());
     }
+
     @GetMapping("/nickname")
+    @Operation(summary = "find user by nickname")
     public ResponseEntity<CustomResponseDto<UserResponseDto>> findUserByNickname(@RequestParam("nickname") String nickname) {
         User user = userRetrieveService.getUserOrExceptionByNickname(nickname);
         return ApiResponse.success(user.toResponseDto());
     }
+
     @PostMapping("")
+    @Operation(summary = "save user ( never use it!!!! )")
     public ResponseEntity<CustomResponseDto<UserResponseDto>> saveUser(@RequestBody UserCreateDto userCreateDto) {
         return ApiResponse.success(userUpdateService.createUser(userCreateDto).toResponseDto());
     }
+
     @PutMapping("/password")
+    @Operation(summary = "update user's password")
     public ResponseEntity<CustomResponseDto<String>> updatePassword(@RequestBody UserPasswordUpdateDto updateDto) {
         userUpdateService.updatePassword(updateDto);
         return ApiResponse.success(SuccessFlag.SUCCESS.getLabel());
     }
+
     @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "update user's profile")
     public ResponseEntity<CustomResponseDto<UserProfileUpdateResponseDto>> updateProfile(
             @RequestHeader(AuthConstants.ACCESS_TOKEN_HEADER_KEY) String accessToken,
             @RequestPart(value = "nickname") String nickname,

--- a/backend/verification-service/src/main/java/com/capstone/controller/VerificationController.java
+++ b/backend/verification-service/src/main/java/com/capstone/controller/VerificationController.java
@@ -7,6 +7,7 @@ import com.capstone.response.ApiResponse;
 import com.capstone.response.CustomResponseDto;
 import com.capstone.service.UserInfoVerificationService;
 import com.capstone.service.VerificationService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -30,6 +31,7 @@ public class VerificationController {
      * @return success if auth code is valid
      * */
     @GetMapping("/nicknames")
+    @Operation(summary = "check nickname is valid")
     public Mono<ResponseEntity<CustomResponseDto<String>>> checkNickname(@RequestParam(name="nickname") String nickname){
         return userVerificationService.isValidNickname(nickname)
                 .map(res -> {
@@ -43,6 +45,7 @@ public class VerificationController {
      * @return success if auth code is valid
      * */
     @GetMapping("/emails")
+    @Operation(summary = "check email is valid")
     public Mono<ResponseEntity<CustomResponseDto<String>>> checkEmail(@RequestParam(name="email") String email){
         return userVerificationService.isValidEmail(email)
                 .map(res -> {
@@ -56,6 +59,7 @@ public class VerificationController {
      * @return success if auth code is valid
     * */
     @GetMapping("/auth-codes")
+    @Operation(summary="send auth code email to user")
     public Mono<ResponseEntity<CustomResponseDto<String>>> sendAuthCodes(@RequestParam(name="email") String email){
         return verificationService.sendVerificationEmail(email).map(res -> {
             if(!res) return ApiResponse.success(SuccessFlag.FAILURE.getLabel());
@@ -69,6 +73,7 @@ public class VerificationController {
      * @return success if auth code is valid
     * */
     @GetMapping("/auth-codes/check")
+    @Operation(summary = "check auth code and give email token to client")
     public Mono<ResponseEntity<CustomResponseDto<EmailTokenResponseDto>>> checkAuthCode(@RequestParam(name="email") String email, @RequestParam(name="authCode") String authCode){
         return verificationService.isValidAuthCode(email, authCode)
                 .flatMap(res -> {


### PR DESCRIPTION
1. 악보 채점 방식이 박자 감지에 더 높은 배분을 주도록 수정
- 박자 감지 : 70%
- 음표 감지 : 30%

2. 테스트 데이터 생성시 실제 악보를 기반으로 연습 정보를 생성하도록 수정

3. swagger 기반 music-service의 각 api에 설명 추가 